### PR TITLE
Add Menu to HD Addons Menu, localize Option title for re-use

### DIFF
--- a/LANGUAGE
+++ b/LANGUAGE
@@ -1,0 +1,3 @@
+[en default]
+
+REENFORCEMENTS_MENU = "\c[Brown]Ⓡ\c- HDest Re-Enforcements";

--- a/MENUDEF.aloadthisfirst
+++ b/MENUDEF.aloadthisfirst
@@ -1,10 +1,15 @@
 OptionMenu HDestReEnforcements
 {
-	Title "HDest Re-Enforcements Options"
+	Title "$REENFORCEMENTS_MENU"
 	StaticText "Monster Module Options", "cyan"
 }
 
 AddOptionMenu "OptionsMenu"
 {
-	Submenu "HDest Re-Enforcements Options", "HDestReEnforcements"
+	Submenu "$REENFORCEMENTS_MENU", "HDestReEnforcements"
+}
+
+AddOptionMenu "HDAddonMenu"
+{
+	Submenu "$REENFORCEMENTS_MENU", "HDestReEnforcements"
 }


### PR DESCRIPTION
I can do more if you'd like, but I noticed a lack of menus in the HD Addons menu, so I wanted to at least get this added.